### PR TITLE
Clarification on Focus

### DIFF
--- a/character-creation.md
+++ b/character-creation.md
@@ -13,6 +13,7 @@
 * Channeling: number of actions per turn
 * Speed: determines turn order and reaction speed value
 * Focus: reduces deck size
+I'm not sure what you mean with Focus
 * Memory: increases hand size
 * color identity
 


### PR DESCRIPTION
I would like to know why focus reduces deck size. Shouldn't it deal with how many abilities you can have active at a time
